### PR TITLE
Fix script path and update to run with bash

### DIFF
--- a/1-integration-test/scripts/run-integration.sh
+++ b/1-integration-test/scripts/run-integration.sh
@@ -1,6 +1,6 @@
 docker-compose up -d
 echo '🟡 - Waiting for database to be ready...'
-./wait-for-it.sh "postgresql://postgres:mysecretpassword@localhost:5432/postgres" -- echo '🟢 - Database is ready!'
+bash ./scripts/wait-for-it.sh "postgresql://postgres:mysecretpassword@localhost:5432/postgres" -- echo '🟢 - Database is ready!'
 npx prisma migrate dev --name init
 npm run test
 docker-compose down


### PR DESCRIPTION
This pull request addresses two improvements to the integration script run-integration.sh:

Corrected Script Path: The relative path to wait-for-it.sh has been updated to ensure it's referenced correctly within run-integration.sh.
Enforced Bash Execution: By default, GitHub Actions uses the sh shell, which can cause issues with script `wait-for-it.sh` due to its Bash-specific syntax. This PR modifies the execution to use bash explicitly, preventing these syntax errors.
This update ensures the integration script runs smoothly and avoids potential errors due to incorrect paths and shell interpretation.